### PR TITLE
image-to-text should use mktemp

### DIFF
--- a/image-to-text
+++ b/image-to-text
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-path=`mktemp -d /tmp/image-to-text-XXXXXX`
+path=`mktemp -d /tmp/image-to-text-XXXXXX` || exit 1
 
 xclip -selection clipboard -t image/png -o > "$path/out.png"
 tesseract "$path/out.png" "$path/out.txt"

--- a/image-to-text
+++ b/image-to-text
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-path="/tmp/$RANDOM"
-mkdir -p "$path"
+path=`mktemp -d /tmp/image-to-text-XXXXXX`
 
 xclip -selection clipboard -t image/png -o > "$path/out.png"
 tesseract "$path/out.png" "$path/out.txt"


### PR DESCRIPTION
Fixes a security issue where another local user can make you overwrite any of your own files:

```shell
for i in {0..32767}
do
    mkdir /tmp/$i
    ln -sf /home/pry0cc/super_important /tmp/$i/out.png
done
```
Wait for user pry0cc to run `image-to-text` and watch `/home/pry0cc/super_important` disappear ;-)

Very cool idea though!